### PR TITLE
Trim trailing whitespace on email entry

### DIFF
--- a/components/login.tsx
+++ b/components/login.tsx
@@ -81,7 +81,7 @@ export default function Info() {
             <TextInput
               // label="Email"
               // leftIcon={{ type: "font-awesome", name: "envelope" }}
-              onChangeText={(text) => setEmail(text)}
+              onChangeText={(text) => setEmail(text.trimEnd())}
               value={email}
               placeholder="email@address.com"
               textContentType="emailAddress"


### PR DESCRIPTION
Is this the idiomatic way to do it? I feel it should probably possibly trigger not on text change but only on submit - now it feels a bit strange that you cannot even enter a whitespace at the end.